### PR TITLE
removed estimation control_dim since it's unused.

### DIFF
--- a/helios_runtime/src/pipeline/estimation_core.rs
+++ b/helios_runtime/src/pipeline/estimation_core.rs
@@ -24,8 +24,6 @@ pub struct EstimationCore {
     pub estimator: Option<Box<dyn StateEstimator>>,
     pub slam: Option<Box<dyn SlamSystem>>,
     pub(crate) last_u: Control,
-    #[allow(dead_code)]
-    pub(crate) control_dim: usize,
 }
 
 impl EstimationCore {


### PR DESCRIPTION
fix #13 
The dead code was actually in estimation and not in mod pipeline