### PR TITLE
Refactor/new autonomy pipeline

### DIFF
--- a/helios_runtime/src/pipeline/build_error.rs
+++ b/helios_runtime/src/pipeline/build_error.rs
@@ -1,0 +1,39 @@
+use crate::port::ChannelKey;
+
+#[derive(Debug)]
+pub enum PipelineBuildError {
+    Cycle,
+    UnsatisfiedInput {
+        node_name: String,
+        channel: ChannelKey,
+    },
+    MultipleProducers {
+        channel: ChannelKey,
+        first_node: String,
+        second_node: String,
+    },
+}
+
+// default source() returns None which is okay
+impl std::error::Error for PipelineBuildError {}
+
+impl std::fmt::Display for PipelineBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PipelineBuildError::Cycle => write!(
+                f,
+                "pipeline has a dependency cycle — no valid topological ordering exists"
+            ),
+            PipelineBuildError::UnsatisfiedInput { node_name, channel } => {
+                write!(f, "node \"{node_name}\" requires channel {channel} but no upstream node or signal key produces it")
+            }
+            PipelineBuildError::MultipleProducers {
+                channel,
+                first_node,
+                second_node,
+            } => {
+                write!(f, "channel {channel} is declared as an output by both \"{first_node}\" and \"{second_node}\" — at most one node may produce a channel")
+            }
+        }
+    }
+}

--- a/helios_runtime/src/pipeline/build_error.rs
+++ b/helios_runtime/src/pipeline/build_error.rs
@@ -1,12 +1,27 @@
 use crate::port::ChannelKey;
 
+/// Errors produced by [`NodePipelineBuilder::build`](super::NodePipelineBuilder::build).
+///
+/// `build` collects every detected error and returns them as a `Vec`
+/// rather than short-circuiting, so a misconfigured pipeline reports all
+/// problems in one pass. Disjoint from
+/// [`ConfigValidationError`](crate::validation::ConfigValidationError),
+/// which checks that TOML strings reference real registry keys — this
+/// type checks DAG structure.
 #[derive(Debug)]
 pub enum PipelineBuildError {
+    /// The dependency graph has no valid topological ordering. At least
+    /// one set of nodes has every input satisfied only by each others'
+    /// outputs.
     Cycle,
+    /// A node declared a required input that no other node produces and
+    /// that is not in the builder's sensor-signal or host-state lists.
     UnsatisfiedInput {
         node_name: String,
         channel: ChannelKey,
     },
+    /// Two nodes both declared the same channel as one of their outputs.
+    /// At most one producer per channel is allowed.
     MultipleProducers {
         channel: ChannelKey,
         first_node: String,

--- a/helios_runtime/src/pipeline/mod.rs
+++ b/helios_runtime/src/pipeline/mod.rs
@@ -25,18 +25,24 @@
 //!     .build();
 //! ```
 
+pub mod build_error;
 pub mod builders;
 pub mod control_core;
 pub mod estimation_core;
 pub mod mapping_core;
 pub mod node;
+pub mod node_pipeline;
 pub mod path_following_core;
+pub mod rate_gate;
 
 pub use control_core::ControlCore;
 pub use estimation_core::EstimationCore;
 pub use mapping_core::MappingCore;
 pub use node::{NodeId, PipelineNode, TickContext};
 pub use path_following_core::PathFollowingCore;
+
+pub use build_error::PipelineBuildError;
+pub use node_pipeline::{NodePipeline, NodePipelineBuilder};
 
 use std::collections::HashMap;
 

--- a/helios_runtime/src/pipeline/mod.rs
+++ b/helios_runtime/src/pipeline/mod.rs
@@ -38,13 +38,12 @@ pub mod rate_gate;
 pub use control_core::ControlCore;
 pub use estimation_core::EstimationCore;
 pub use mapping_core::MappingCore;
-pub use node::{NodeId, PipelineNode, TickContext};
+pub use node::{NodeId, PipelineNode, TickContext, HOST_PRODUCER_ID};
+pub use node_pipeline::MISSION_GOAL_INSTANCE;
 pub use path_following_core::PathFollowingCore;
 
 pub use build_error::PipelineBuildError;
-pub use node_pipeline::{
-    NodePipeline, NodePipelineBuilder, HOST_PRODUCER_ID, MISSION_GOAL_INSTANCE,
-};
+pub use node_pipeline::{NodePipeline, NodePipelineBuilder};
 
 use std::collections::HashMap;
 

--- a/helios_runtime/src/pipeline/mod.rs
+++ b/helios_runtime/src/pipeline/mod.rs
@@ -42,7 +42,9 @@ pub use node::{NodeId, PipelineNode, TickContext};
 pub use path_following_core::PathFollowingCore;
 
 pub use build_error::PipelineBuildError;
-pub use node_pipeline::{NodePipeline, NodePipelineBuilder};
+pub use node_pipeline::{
+    NodePipeline, NodePipelineBuilder, HOST_PRODUCER_ID, MISSION_GOAL_INSTANCE,
+};
 
 use std::collections::HashMap;
 

--- a/helios_runtime/src/pipeline/node.rs
+++ b/helios_runtime/src/pipeline/node.rs
@@ -3,18 +3,58 @@ use crate::runtime::AgentRuntime;
 
 use helios_core::data::primitives::MonotonicTime;
 
+/// One unit of computation in an [`AutonomyPipeline`](super::NodePipeline).
+///
+/// Nodes declare their bus interaction (inputs, outputs, rate) via
+/// [`port_descriptor`](PipelineNode::port_descriptor). The pipeline calls
+/// [`execute`](PipelineNode::execute) once per tick on every node whose
+/// [`RateTimer`](super::rate_gate::RateTimer) is due — in topological order
+/// across levels.
+///
+/// Implementations must be `Send + Sync`. `execute` takes `&self`; any mutable
+/// algorithm state (e.g. an EKF filter) must live behind a `Mutex` or atomic.
+/// This is what lets a level later be executed in parallel without changing
+/// the trait signature.
+///
+/// All reads and writes go through `bus`. Producers stamp values with
+/// `tick.now` and `tick.node_id`; consumers should early-return when an
+/// input is `None` (cold-start, sensor dropout, or a rate-gated upstream
+/// node that has not fired yet).
 pub trait PipelineNode: Send + Sync {
+    /// Human-readable identifier used in build errors and diagnostics.
     fn name(&self) -> &str;
 
+    /// Describes the bus channels this node reads and writes, plus its
+    /// execution rate. Returned by reference because the descriptor is
+    /// immutable after construction.
     fn port_descriptor(&self) -> &PortDescriptor;
 
+    /// Run one iteration. Called by [`NodePipeline::tick`](super::NodePipeline::tick).
     fn execute(&self, bus: &PortBus, runtime: &dyn AgentRuntime, tick: TickContext);
 }
 
+/// Per-execution context passed to every [`PipelineNode::execute`] call.
+///
+/// `now` and `dt` are sourced from the [`AgentRuntime`] so simulation and
+/// hardware share the same clock semantics. `node_id` lets a node tag the
+/// values it writes to the bus with its own identity for diagnostics.
 pub struct TickContext {
     pub now: MonotonicTime,
     pub dt: f64,
     pub node_id: NodeId,
 }
 
+/// Build-time-assigned identifier for a [`PipelineNode`].
+///
+/// IDs are assigned in level-major order starting at `0` and index into the
+/// pipeline's rate-timer array. Used as the `producer` field on
+/// [`Stamped`](crate::stamped::Stamped) values written to the bus.
 pub type NodeId = u32;
+
+/// Sentinel [`NodeId`] used as the `producer` field on bus writes that
+/// originate **outside** the pipeline graph — e.g. a mission goal injected
+/// by a Zenoh bridge or sensor batches written by the host tick system.
+///
+/// `NodeId::MAX` is chosen so the sentinel cannot collide with a real
+/// assigned ID (which counts up from 0 and is bounded by the node count).
+pub const HOST_PRODUCER_ID: NodeId = NodeId::MAX;

--- a/helios_runtime/src/pipeline/node_pipeline.rs
+++ b/helios_runtime/src/pipeline/node_pipeline.rs
@@ -11,13 +11,19 @@ use helios_core::{
 use crate::{
     pipeline::rate_gate::RateTimer,
     port::{ChannelKey, PortBus},
-    prelude::{AgentRuntime, NodeId, PipelineBuildError, PipelineNode, Stamped},
+    prelude::{
+        AgentRuntime, Health, NodeId, PipelineBuildError, PipelineNode, Stamped, TickContext,
+    },
 };
+
+// Constant Sentinal Values
+pub const MISSION_GOAL_INSTANCE: &str = "mission";
+pub const HOST_PRODUCER_ID: NodeId = NodeId::MAX;
 
 pub struct NodePipelineBuilder {
     nodes: Vec<Box<dyn PipelineNode>>,
     sensor_signal_keys: Vec<ChannelKey>,
-    host_signal_keys: Vec<ChannelKey>,
+    host_state_keys: Vec<ChannelKey>,
 }
 
 impl Default for NodePipelineBuilder {
@@ -31,7 +37,7 @@ impl NodePipelineBuilder {
         NodePipelineBuilder {
             nodes: vec![],
             sensor_signal_keys: vec![],
-            host_signal_keys: vec![],
+            host_state_keys: vec![],
         }
     }
 
@@ -45,8 +51,8 @@ impl NodePipelineBuilder {
         self
     }
 
-    pub fn with_host_signals(mut self, keys: Vec<ChannelKey>) -> Self {
-        self.host_signal_keys = keys;
+    pub fn with_host_states(mut self, keys: Vec<ChannelKey>) -> Self {
+        self.host_state_keys = keys;
         self
     }
 
@@ -78,7 +84,7 @@ impl NodePipelineBuilder {
         // which should be just host/sensor signals
         let mut produced: HashSet<ChannelKey> = HashSet::new();
         produced.extend(self.sensor_signal_keys.iter().cloned());
-        produced.extend(self.host_signal_keys.iter().cloned());
+        produced.extend(self.host_state_keys.iter().cloned());
 
         let mut remaining: Vec<Box<dyn PipelineNode>> = self.nodes;
         let mut levels: Vec<Vec<(NodeId, Box<dyn PipelineNode>)>> = Vec::new();
@@ -172,8 +178,7 @@ impl NodePipelineBuilder {
             .iter()
             .flat_map(|level| level.iter().map(|(_, node)| node.port_descriptor()));
 
-        let mut signals = self.sensor_signal_keys;
-        signals.extend(self.host_signal_keys);
+        let signals = self.sensor_signal_keys;
 
         // create bus with descriptors and signals
         let bus = PortBus::new(descriptor_iter, signals);
@@ -205,19 +210,51 @@ impl NodePipeline {
         &self.bus
     }
 
-    pub fn tick(&self, _runtime: &dyn AgentRuntime, _dt: f64) {
+    pub fn tick(&self, runtime: &dyn AgentRuntime, dt: f64) {
+        let now = runtime.now();
+        self.bus.set_tick_time(now.0);
+
+        // level by level, execute each node if the it meets the rate
+        for level in &self.levels {
+            for (node_id, node) in level {
+                if self.rate_timers[*node_id as usize].should_fire_and_advance(dt) {
+                    node.execute(
+                        &self.bus,
+                        runtime,
+                        TickContext {
+                            now,
+                            dt,
+                            node_id: *node_id,
+                        },
+                    );
+                }
+            }
+        }
+
         todo!()
     }
 
-    pub fn inject_mission_goal(&self, _goal: PlannerGoal, _runtime: &dyn AgentRuntime) {
+    pub fn inject_mission_goal(&self, goal: PlannerGoal, runtime: &dyn AgentRuntime) {
+        let now = runtime.now();
+        let goal_stamped = Stamped {
+            value: goal,
+            timestamp: now,
+            health: Health::Ok,
+            producer: HOST_PRODUCER_ID,
+        };
+
+        let _ = self.bus.write(
+            ChannelKey::named::<PlannerGoal>(MISSION_GOAL_INSTANCE),
+            goal_stamped,
+        );
         todo!()
     }
 
     pub fn read_state(&self) -> Option<Arc<Stamped<FrameAwareState>>> {
-        todo!()
+        self.bus.read(ChannelKey::of::<FrameAwareState>())
     }
 
     pub fn read_control(&self) -> Option<Arc<Stamped<ControlOutput>>> {
-        todo!()
+        self.bus.read(ChannelKey::of::<ControlOutput>())
     }
 }

--- a/helios_runtime/src/pipeline/node_pipeline.rs
+++ b/helios_runtime/src/pipeline/node_pipeline.rs
@@ -230,8 +230,6 @@ impl NodePipeline {
                 }
             }
         }
-
-        todo!()
     }
 
     pub fn inject_mission_goal(&self, goal: PlannerGoal, runtime: &dyn AgentRuntime) {
@@ -247,7 +245,6 @@ impl NodePipeline {
             ChannelKey::named::<PlannerGoal>(MISSION_GOAL_INSTANCE),
             goal_stamped,
         );
-        todo!()
     }
 
     pub fn read_state(&self) -> Option<Arc<Stamped<FrameAwareState>>> {

--- a/helios_runtime/src/pipeline/node_pipeline.rs
+++ b/helios_runtime/src/pipeline/node_pipeline.rs
@@ -9,17 +9,40 @@ use helios_core::{
 };
 
 use crate::{
-    pipeline::rate_gate::RateTimer,
+    pipeline::{node::HOST_PRODUCER_ID, rate_gate::RateTimer},
     port::{ChannelKey, PortBus},
     prelude::{
         AgentRuntime, Health, NodeId, PipelineBuildError, PipelineNode, Stamped, TickContext,
     },
 };
 
-// Constant Sentinal Values
+/// Canonical [`ChannelKey`] instance name for the long-lived mission goal slot.
+///
+/// `PlannerGoal @ "mission"` is a **state** channel (last-known-good, not
+/// cleared each tick). Any code writing to it — `inject_mission_goal`, a
+/// Zenoh bridge, the mission layer — must use this constant rather than a
+/// duplicated literal so the contract stays in one place.
 pub const MISSION_GOAL_INSTANCE: &str = "mission";
-pub const HOST_PRODUCER_ID: NodeId = NodeId::MAX;
 
+/// Constructs a [`NodePipeline`] from a set of [`PipelineNode`]s and the
+/// channels supplied from outside the graph.
+///
+/// Build sequence:
+/// 1. Register every node with [`add_node`](Self::add_node).
+/// 2. Declare channels written by sensor tick systems via
+///    [`with_sensor_signals`](Self::with_sensor_signals). These slots are
+///    cleared each tick by [`PortBus::clear_signals`].
+/// 3. Declare channels written by external systems (mission layer, Zenoh,
+///    operator UI) via [`with_host_states`](Self::with_host_states). These
+///    persist across ticks.
+/// 4. Call [`build`](Self::build) — returns either a fully validated
+///    pipeline or every detected error.
+///
+/// Both `with_sensor_signals` and `with_host_states` seed the topological
+/// sort so a node consuming an externally-provided channel doesn't fail
+/// with [`PipelineBuildError::UnsatisfiedInput`]. The split between them
+/// only affects `PortBus`'s signal-clear list: sensor signals get cleared
+/// each tick; host states do not.
 pub struct NodePipelineBuilder {
     nodes: Vec<Box<dyn PipelineNode>>,
     sensor_signal_keys: Vec<ChannelKey>,
@@ -33,6 +56,8 @@ impl Default for NodePipelineBuilder {
 }
 
 impl NodePipelineBuilder {
+    /// Creates an empty builder. Add nodes and declare external channels
+    /// before calling [`build`](Self::build).
     pub fn new() -> Self {
         NodePipelineBuilder {
             nodes: vec![],
@@ -41,34 +66,60 @@ impl NodePipelineBuilder {
         }
     }
 
+    /// Registers one node. Order does not matter — the topological sort
+    /// places each node in the correct level based on its declared inputs
+    /// and outputs.
     pub fn add_node(mut self, node: Box<dyn PipelineNode>) -> Self {
         self.nodes.push(node);
         self
     }
 
+    /// Declares channels written by sensor tick systems each tick.
+    ///
+    /// These keys are passed to [`PortBus::clear_signals`] so the slot is
+    /// wiped at the start of every tick — sensor batches must not carry
+    /// across ticks.
     pub fn with_sensor_signals(mut self, keys: Vec<ChannelKey>) -> Self {
         self.sensor_signal_keys = keys;
         self
     }
 
+    /// Declares persistent channels written by external systems
+    /// (mission layer, Zenoh bridge, operator UI).
+    ///
+    /// Unlike sensor signals, these slots are **not** cleared each tick —
+    /// the host writes once when the value changes, consumers read the
+    /// last-known-good value on every subsequent tick. This is the slot
+    /// semantics needed for mission goals, mode flags, and parameter
+    /// overrides.
     pub fn with_host_states(mut self, keys: Vec<ChannelKey>) -> Self {
         self.host_state_keys = keys;
         self
     }
 
+    /// Validates the registered nodes and builds a [`NodePipeline`].
+    ///
+    /// All errors are collected — `build` never short-circuits. The
+    /// returned [`Vec`] contains every issue found, in this order:
+    /// 1. [`PipelineBuildError::MultipleProducers`] — two nodes declared
+    ///    the same output channel.
+    /// 2. [`PipelineBuildError::UnsatisfiedInput`] — a required input has
+    ///    no producer and is not in the sensor/host declarations.
+    /// 3. [`PipelineBuildError::Cycle`] — a remaining sub-graph has every
+    ///    input satisfied only by other stranded nodes' outputs.
+    ///
+    /// On success, [`NodeId`]s are assigned in level-major order starting
+    /// at `0`, indexing into the pipeline's rate-timer array.
     pub fn build(self) -> Result<NodePipeline, Vec<PipelineBuildError>> {
         let mut errors: Vec<PipelineBuildError> = vec![];
+
+        // First pass: single-producer check. For each output channel of
+        // each node, record the first node that claims it; any later
+        // claimant is a conflict.
         let mut producer_of: HashMap<ChannelKey, String> = HashMap::new();
-
         for node in &self.nodes {
-            // get the outputs to check if there are multiple node producers
-            let outputs = &node.port_descriptor().outputs;
             let node_name = node.name();
-
-            // each output has the same node name
-            for output in outputs {
-                // if the channel_key gets updated, then we have multiple producers
-                // and we collect the error to relay to the user
+            for output in &node.port_descriptor().outputs {
                 if let Some(prev_name) = producer_of.insert(output.clone(), node_name.to_string()) {
                     let error = PipelineBuildError::MultipleProducers {
                         channel: output.clone(),
@@ -80,12 +131,17 @@ impl NodePipelineBuilder {
             }
         }
 
-        // Filling out the produced channels which require no input
-        // which should be just host/sensor signals
+        // Seed `produced` with channels supplied from outside the graph.
+        // The topological sort treats them as already-satisfied so any
+        // consumer of these channels doesn't trip UnsatisfiedInput.
         let mut produced: HashSet<ChannelKey> = HashSet::new();
         produced.extend(self.sensor_signal_keys.iter().cloned());
         produced.extend(self.host_state_keys.iter().cloned());
 
+        // Kahn's algorithm (level-by-level form). Each iteration pulls out
+        // every node whose required inputs are already produced, assigns
+        // it a NodeId, and pushes it into the current level. The level's
+        // outputs then enter `produced` so the next iteration can advance.
         let mut remaining: Vec<Box<dyn PipelineNode>> = self.nodes;
         let mut levels: Vec<Vec<(NodeId, Box<dyn PipelineNode>)>> = Vec::new();
         let mut next_id: NodeId = 0;
@@ -101,11 +157,11 @@ impl NodePipelineBuilder {
 
             remaining = still_waiting;
 
-            // if ready is empty, the graph cannot advance further
-            // since the remaining nodes don't have their inputs satisfied
-            // or a cycle has occurred
+            // If no node is ready but `remaining` is non-empty, the sort
+            // is stuck. Either an input has no producer anywhere, or two
+            // or more nodes are mutually waiting on each other (cycle).
             if ready.is_empty() {
-                // build the outputs as though we continued creating the graph
+                // Channels that *would* exist if the sort could continue.
                 let mut pending_outputs: HashSet<ChannelKey> = HashSet::new();
                 for node in &remaining {
                     for channel in &node.port_descriptor().outputs {
@@ -113,10 +169,11 @@ impl NodePipelineBuilder {
                     }
                 }
 
-                // Are there any remaining node whose all required input is accounted
-                // for whether it's in already in the produces bus or from another
-                // remaining node. If so, there is a cycle because all inputs are
-                // given but we cannot progress further
+                // Cycle pass: a remaining node whose required inputs are
+                // entirely covered by `produced ∪ pending_outputs` is
+                // blocked purely by other stranded nodes — that is a
+                // cycle. One Cycle error is emitted regardless of how
+                // many nodes participate.
                 let is_cycle_detected = remaining.iter().any(|node| {
                     node.port_descriptor()
                         .required_inputs
@@ -130,16 +187,16 @@ impl NodePipelineBuilder {
                     errors.push(PipelineBuildError::Cycle);
                 }
 
-                // if nothing produced the channel for required_inputs, then
-                // we have a missing input
+                // Unsatisfied-input pass: any required input not covered
+                // by `produced` *or* `pending_outputs` is genuinely
+                // missing — no node anywhere will ever produce it.
                 for node in &remaining {
                     for channel in &node.port_descriptor().required_inputs {
                         if !produced.contains(channel) && !pending_outputs.contains(channel) {
-                            let error = PipelineBuildError::UnsatisfiedInput {
+                            errors.push(PipelineBuildError::UnsatisfiedInput {
                                 node_name: node.name().to_string(),
                                 channel: channel.clone(),
-                            };
-                            errors.push(error);
+                            });
                         }
                     }
                 }
@@ -147,8 +204,8 @@ impl NodePipelineBuilder {
                 break;
             }
 
-            // add each node's outputs as part of the produced data
-            // we abstract each node which has a vec of outputs and flatten them to 1D
+            // Promote this level's outputs into `produced` so the next
+            // iteration can advance.
             produced.extend(
                 ready
                     .iter()
@@ -156,14 +213,15 @@ impl NodePipelineBuilder {
                     .cloned(),
             );
 
-            // create the level and push the ready nodes to this level
+            // Assign NodeIds in level-major order as we go — this is the
+            // same order the rate-timer array will be indexed by at tick
+            // time, so the two stay in lockstep without a second pass.
             let mut level: Vec<(NodeId, Box<dyn PipelineNode>)> = Vec::with_capacity(ready.len());
             for node in ready {
                 level.push((next_id, node));
                 next_id += 1;
             }
 
-            // push the level to the levels graph
             levels.push(level);
         }
 
@@ -171,20 +229,23 @@ impl NodePipelineBuilder {
             return Err(errors);
         }
 
-        // now we have a guaranteed DAG, may not necessarily
-        // be completely useful in terms of autonomy but we
-        // know that there is no config time errors
+        // Bus slots are allocated from the union of all node descriptors.
+        // A host-state channel gets its slot via the consuming node's
+        // `required_inputs` (or `optional_inputs`) — no need to seed slots
+        // from `host_state_keys` separately. If no node consumes a host
+        // channel, the host write returns `UnknownChannel`, which is the
+        // correct outcome.
         let descriptor_iter = levels
             .iter()
             .flat_map(|level| level.iter().map(|(_, node)| node.port_descriptor()));
 
-        let signals = self.sensor_signal_keys;
+        // Only sensor signals go into the bus's signal-clear list. Host
+        // states must persist across ticks.
+        let bus = PortBus::new(descriptor_iter, self.sensor_signal_keys);
 
-        // create bus with descriptors and signals
-        let bus = PortBus::new(descriptor_iter, signals);
-
+        // One timer per node, indexed by NodeId (which matches level-major
+        // iteration order below).
         let mut rate_timers: Vec<RateTimer> = Vec::with_capacity(next_id as usize);
-
         for level in &levels {
             for (_, node) in level {
                 rate_timers.push(RateTimer::new(node.port_descriptor().rate));
@@ -199,22 +260,57 @@ impl NodePipelineBuilder {
     }
 }
 
+/// A built, validated autonomy pipeline.
+///
+/// Constructed only via [`NodePipelineBuilder::build`]. After construction
+/// the topology is fixed; the only mutable state is the bus contents and
+/// per-node timer counters, both of which use interior mutability so
+/// [`tick`](Self::tick) can take `&self`.
 pub struct NodePipeline {
+    /// Nodes grouped by topological level, in execution order. Each entry
+    /// pairs a node with its build-time-assigned [`NodeId`].
     levels: Vec<Vec<(NodeId, Box<dyn PipelineNode>)>>,
+    /// Typed blackboard used for all intra-pipeline data exchange. Also
+    /// the only way external systems (host, mission layer) write values
+    /// into the graph.
     bus: PortBus,
+    /// Per-node rate gating, indexed by [`NodeId`]. A node with
+    /// `rate: None` fires every tick.
     rate_timers: Vec<RateTimer>,
 }
 
 impl NodePipeline {
+    /// Returns a reference to the [`PortBus`] for direct read/write access.
+    ///
+    /// External callers use this to:
+    /// - Clear and re-write sensor signals at the start of each tick.
+    /// - Inject host-state values (mission goals, mode flags, etc.) when
+    ///   they change, via [`PortBus::write`].
     pub fn bus(&self) -> &PortBus {
         &self.bus
     }
 
+    /// Executes one tick: stamps the bus clock, then runs every rate-due
+    /// node in topological order.
+    ///
+    /// `tick` deliberately does **not** call [`PortBus::clear_signals`].
+    /// The host owns the per-tick sequence so it can also be driven from
+    /// non-Bevy contexts (hardware loop, replay):
+    ///
+    /// ```text
+    /// pipeline.bus().clear_signals();
+    /// // host writes fresh sensor data into the bus
+    /// pipeline.tick(runtime, dt);
+    /// ```
+    ///
+    /// `dt` is the elapsed wall time since the last call (used by
+    /// [`RateTimer`]). The bus tick-time is sourced from
+    /// [`AgentRuntime::now`] so producers and `read_fresh` consumers
+    /// always see the same clock.
     pub fn tick(&self, runtime: &dyn AgentRuntime, dt: f64) {
         let now = runtime.now();
         self.bus.set_tick_time(now.0);
 
-        // level by level, execute each node if the it meets the rate
         for level in &self.levels {
             for (node_id, node) in level {
                 if self.rate_timers[*node_id as usize].should_fire_and_advance(dt) {
@@ -232,11 +328,21 @@ impl NodePipeline {
         }
     }
 
+    /// Writes a mission goal to the canonical `PlannerGoal @ "mission"`
+    /// channel.
+    ///
+    /// This is a thin wrapper over [`PortBus::write`] for the one channel
+    /// that has a named in-process helper because of how often it's used.
+    /// Any other host-state channel uses `pipeline.bus().write(...)`
+    /// directly.
+    ///
+    /// The write is silently dropped if no node in the graph consumes the
+    /// mission channel (the bus has no slot for it). This is the documented
+    /// behavior for unused channels — see `dag_engine_plan.md` Decision 1.
     pub fn inject_mission_goal(&self, goal: PlannerGoal, runtime: &dyn AgentRuntime) {
-        let now = runtime.now();
         let goal_stamped = Stamped {
             value: goal,
-            timestamp: now,
+            timestamp: runtime.now(),
             health: Health::Ok,
             producer: HOST_PRODUCER_ID,
         };
@@ -247,10 +353,16 @@ impl NodePipeline {
         );
     }
 
+    /// Reads the current ego state, if any node has written one this run.
+    ///
+    /// Returns `None` during cold-start (before the estimator has produced
+    /// its first state) and when no estimator node is present in the graph.
     pub fn read_state(&self) -> Option<Arc<Stamped<FrameAwareState>>> {
         self.bus.read(ChannelKey::of::<FrameAwareState>())
     }
 
+    /// Reads the current control output, if any controller node has
+    /// written one this run.
     pub fn read_control(&self) -> Option<Arc<Stamped<ControlOutput>>> {
         self.bus.read(ChannelKey::of::<ControlOutput>())
     }

--- a/helios_runtime/src/pipeline/node_pipeline.rs
+++ b/helios_runtime/src/pipeline/node_pipeline.rs
@@ -1,0 +1,223 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use helios_core::{
+    frames::FrameAwareState,
+    prelude::{ControlOutput, PlannerGoal},
+};
+
+use crate::{
+    pipeline::rate_gate::RateTimer,
+    port::{ChannelKey, PortBus},
+    prelude::{AgentRuntime, NodeId, PipelineBuildError, PipelineNode, Stamped},
+};
+
+pub struct NodePipelineBuilder {
+    nodes: Vec<Box<dyn PipelineNode>>,
+    sensor_signal_keys: Vec<ChannelKey>,
+    host_signal_keys: Vec<ChannelKey>,
+}
+
+impl Default for NodePipelineBuilder {
+    fn default() -> Self {
+        NodePipelineBuilder::new()
+    }
+}
+
+impl NodePipelineBuilder {
+    pub fn new() -> Self {
+        NodePipelineBuilder {
+            nodes: vec![],
+            sensor_signal_keys: vec![],
+            host_signal_keys: vec![],
+        }
+    }
+
+    pub fn add_node(mut self, node: Box<dyn PipelineNode>) -> Self {
+        self.nodes.push(node);
+        self
+    }
+
+    pub fn with_sensor_signals(mut self, keys: Vec<ChannelKey>) -> Self {
+        self.sensor_signal_keys = keys;
+        self
+    }
+
+    pub fn with_host_signals(mut self, keys: Vec<ChannelKey>) -> Self {
+        self.host_signal_keys = keys;
+        self
+    }
+
+    pub fn build(self) -> Result<NodePipeline, Vec<PipelineBuildError>> {
+        let mut errors: Vec<PipelineBuildError> = vec![];
+        let mut producer_of: HashMap<ChannelKey, String> = HashMap::new();
+
+        for node in &self.nodes {
+            // get the outputs to check if there are multiple node producers
+            let outputs = &node.port_descriptor().outputs;
+            let node_name = node.name();
+
+            // each output has the same node name
+            for output in outputs {
+                // if the channel_key gets updated, then we have multiple producers
+                // and we collect the error to relay to the user
+                if let Some(prev_name) = producer_of.insert(output.clone(), node_name.to_string()) {
+                    let error = PipelineBuildError::MultipleProducers {
+                        channel: output.clone(),
+                        first_node: prev_name,
+                        second_node: node_name.to_string(),
+                    };
+                    errors.push(error);
+                }
+            }
+        }
+
+        // Filling out the produced channels which require no input
+        // which should be just host/sensor signals
+        let mut produced: HashSet<ChannelKey> = HashSet::new();
+        produced.extend(self.sensor_signal_keys.iter().cloned());
+        produced.extend(self.host_signal_keys.iter().cloned());
+
+        let mut remaining: Vec<Box<dyn PipelineNode>> = self.nodes;
+        let mut levels: Vec<Vec<(NodeId, Box<dyn PipelineNode>)>> = Vec::new();
+        let mut next_id: NodeId = 0;
+
+        while !remaining.is_empty() {
+            let (ready, still_waiting): (Vec<_>, Vec<_>) =
+                remaining.into_iter().partition(|node| {
+                    node.port_descriptor()
+                        .required_inputs
+                        .iter()
+                        .all(|channel| produced.contains(channel))
+                });
+
+            remaining = still_waiting;
+
+            // if ready is empty, the graph cannot advance further
+            // since the remaining nodes don't have their inputs satisfied
+            // or a cycle has occurred
+            if ready.is_empty() {
+                // build the outputs as though we continued creating the graph
+                let mut pending_outputs: HashSet<ChannelKey> = HashSet::new();
+                for node in &remaining {
+                    for channel in &node.port_descriptor().outputs {
+                        pending_outputs.insert(channel.clone());
+                    }
+                }
+
+                // Are there any remaining node whose all required input is accounted
+                // for whether it's in already in the produces bus or from another
+                // remaining node. If so, there is a cycle because all inputs are
+                // given but we cannot progress further
+                let is_cycle_detected = remaining.iter().any(|node| {
+                    node.port_descriptor()
+                        .required_inputs
+                        .iter()
+                        .all(|channel| {
+                            produced.contains(channel) || pending_outputs.contains(channel)
+                        })
+                });
+
+                if is_cycle_detected {
+                    errors.push(PipelineBuildError::Cycle);
+                }
+
+                // if nothing produced the channel for required_inputs, then
+                // we have a missing input
+                for node in &remaining {
+                    for channel in &node.port_descriptor().required_inputs {
+                        if !produced.contains(channel) && !pending_outputs.contains(channel) {
+                            let error = PipelineBuildError::UnsatisfiedInput {
+                                node_name: node.name().to_string(),
+                                channel: channel.clone(),
+                            };
+                            errors.push(error);
+                        }
+                    }
+                }
+
+                break;
+            }
+
+            // add each node's outputs as part of the produced data
+            // we abstract each node which has a vec of outputs and flatten them to 1D
+            produced.extend(
+                ready
+                    .iter()
+                    .flat_map(|node| node.port_descriptor().outputs.iter())
+                    .cloned(),
+            );
+
+            // create the level and push the ready nodes to this level
+            let mut level: Vec<(NodeId, Box<dyn PipelineNode>)> = Vec::with_capacity(ready.len());
+            for node in ready {
+                level.push((next_id, node));
+                next_id += 1;
+            }
+
+            // push the level to the levels graph
+            levels.push(level);
+        }
+
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+
+        // now we have a guaranteed DAG, may not necessarily
+        // be completely useful in terms of autonomy but we
+        // know that there is no config time errors
+        let descriptor_iter = levels
+            .iter()
+            .flat_map(|level| level.iter().map(|(_, node)| node.port_descriptor()));
+
+        let mut signals = self.sensor_signal_keys;
+        signals.extend(self.host_signal_keys);
+
+        // create bus with descriptors and signals
+        let bus = PortBus::new(descriptor_iter, signals);
+
+        let mut rate_timers: Vec<RateTimer> = Vec::with_capacity(next_id as usize);
+
+        for level in &levels {
+            for (_, node) in level {
+                rate_timers.push(RateTimer::new(node.port_descriptor().rate));
+            }
+        }
+
+        Ok(NodePipeline {
+            levels,
+            bus,
+            rate_timers,
+        })
+    }
+}
+
+pub struct NodePipeline {
+    levels: Vec<Vec<(NodeId, Box<dyn PipelineNode>)>>,
+    bus: PortBus,
+    rate_timers: Vec<RateTimer>,
+}
+
+impl NodePipeline {
+    pub fn bus(&self) -> &PortBus {
+        &self.bus
+    }
+
+    pub fn tick(&self, _runtime: &dyn AgentRuntime, _dt: f64) {
+        todo!()
+    }
+
+    pub fn inject_mission_goal(&self, _goal: PlannerGoal, _runtime: &dyn AgentRuntime) {
+        todo!()
+    }
+
+    pub fn read_state(&self) -> Option<Arc<Stamped<FrameAwareState>>> {
+        todo!()
+    }
+
+    pub fn read_control(&self) -> Option<Arc<Stamped<ControlOutput>>> {
+        todo!()
+    }
+}

--- a/helios_runtime/src/pipeline/rate_gate.rs
+++ b/helios_runtime/src/pipeline/rate_gate.rs
@@ -1,0 +1,42 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+pub(crate) struct RateTimer {
+    period_secs: Option<f64>,
+    elapsed_micros: AtomicU64,
+}
+
+impl RateTimer {
+    pub(crate) fn new(rate_hz: Option<f64>) -> Self {
+        let period_secs = rate_hz.map(|rate| 1.0f64 / rate);
+
+        RateTimer {
+            period_secs,
+            elapsed_micros: AtomicU64::new(0u64),
+        }
+    }
+
+    pub(crate) fn should_fire_and_advance(&self, dt: f64) -> bool {
+        let Some(period) = self.period_secs else {
+            return false;
+        };
+
+        let period_micros = (period * 1_000_000f64) as u64;
+        let dt_micros = (dt * 1_000_000f64) as u64;
+
+        let prev = self.elapsed_micros.fetch_add(dt_micros, Ordering::Relaxed);
+
+        let new = prev + dt_micros;
+
+        if new < period_micros {
+            return false;
+        }
+
+        // last time fired and now have met the run rate.
+        // attempt to reset elapsed time to be 0
+        // if another thread already incremented, then the compare
+        // and swap fails - letting one to claim the update
+        self.elapsed_micros
+            .compare_exchange(new, 0, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+    }
+}

--- a/helios_runtime/src/pipeline/rate_gate.rs
+++ b/helios_runtime/src/pipeline/rate_gate.rs
@@ -1,11 +1,33 @@
+//! Per-node rate gating.
+//!
+//! One [`RateTimer`] lives in [`NodePipeline`](super::NodePipeline)'s
+//! `rate_timers` vector per [`NodeId`](super::node::NodeId). Each tick,
+//! the pipeline calls [`RateTimer::should_fire_and_advance`] for every
+//! node; only nodes whose elapsed time has crossed their configured
+//! period actually execute. Slow-tick double-firing is **not** corrected
+//! — see `should_fire_and_advance` for details.
+
 use std::sync::atomic::{AtomicU64, Ordering};
 
+/// Accumulates elapsed time and reports when a node is due to fire.
+///
+/// `elapsed_micros` is an [`AtomicU64`] rather than a `Mutex<f64>` so
+/// [`NodePipeline::tick`](super::NodePipeline::tick) can advance every
+/// timer through a shared `&self` reference without acquiring any lock.
+/// No panic can poison shared state across ticks, and a future
+/// `par_iter`-within-a-level optimization remains a one-line change.
 pub(crate) struct RateTimer {
+    /// `None` means "fire every tick" (no rate limit). Set at
+    /// construction; immutable thereafter.
     period_secs: Option<f64>,
+    /// Microseconds since the last fire. Reset to `0` on each successful
+    /// fire; never reset otherwise.
     elapsed_micros: AtomicU64,
 }
 
 impl RateTimer {
+    /// Creates a timer with the given fire rate. `None` means the node
+    /// fires every tick.
     pub(crate) fn new(rate_hz: Option<f64>) -> Self {
         let period_secs = rate_hz.map(|rate| 1.0f64 / rate);
 
@@ -15,6 +37,26 @@ impl RateTimer {
         }
     }
 
+    /// Adds `dt` to the accumulator and returns whether the node should
+    /// execute on this tick.
+    ///
+    /// Returns:
+    /// - `true` unconditionally when `period_secs` is `None`.
+    /// - `true` when accumulated elapsed time has crossed the period —
+    ///   the accumulator is reset to `0` before returning.
+    /// - `false` otherwise.
+    ///
+    /// **No catch-up:** if a single `dt` covers multiple periods (e.g.
+    /// `dt = 1.0` with `period = 0.5`), the node still fires exactly once.
+    /// This matches the design intent — rate-gated nodes must not
+    /// double-fire after a slow tick.
+    ///
+    /// **Concurrency:** with one caller per timer per tick (the only
+    /// shape `NodePipeline::tick` ever calls in), the `compare_exchange`
+    /// always succeeds. The CAS is defensive: if a future change ever
+    /// adds parallel within-level execution that touched the same timer,
+    /// it would still fire at most once per period rather than
+    /// `store(0)`-clobbering a concurrent increment.
     pub(crate) fn should_fire_and_advance(&self, dt: f64) -> bool {
         let Some(period) = self.period_secs else {
             return true;
@@ -24,20 +66,13 @@ impl RateTimer {
         let dt_micros = (dt * 1_000_000f64) as u64;
 
         let prev = self.elapsed_micros.fetch_add(dt_micros, Ordering::Relaxed);
-
         let new = prev + dt_micros;
 
         if new < period_micros {
             return false;
         }
 
-        // TODO: I think this will make multithreading per node
-        //       actually single threading since one thread will
-        //       beat the rest and reset the timer
-        // last time fired and now have met the run rate.
-        // attempt to reset elapsed time to be 0
-        // if another thread already incremented, then the compare
-        // and swap fails - letting one to claim the update
+        // Compare current with new time and swap with 0 if succeeeds
         self.elapsed_micros
             .compare_exchange(new, 0, Ordering::Relaxed, Ordering::Relaxed)
             .is_ok()

--- a/helios_runtime/src/pipeline/rate_gate.rs
+++ b/helios_runtime/src/pipeline/rate_gate.rs
@@ -17,7 +17,7 @@ impl RateTimer {
 
     pub(crate) fn should_fire_and_advance(&self, dt: f64) -> bool {
         let Some(period) = self.period_secs else {
-            return false;
+            return true;
         };
 
         let period_micros = (period * 1_000_000f64) as u64;
@@ -31,6 +31,9 @@ impl RateTimer {
             return false;
         }
 
+        // TODO: I think this will make multithreading per node
+        //       actually single threading since one thread will
+        //       beat the rest and reset the timer
         // last time fired and now have met the run rate.
         // attempt to reset elapsed time to be 0
         // if another thread already incremented, then the compare

--- a/helios_runtime/src/port.rs
+++ b/helios_runtime/src/port.rs
@@ -47,6 +47,16 @@ impl ChannelKey {
     }
 }
 
+impl std::fmt::Display for ChannelKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.instance.trim().is_empty() {
+            write!(f, "{}", self.type_name)
+        } else {
+            write!(f, "{} @ \"{}\"", self.type_name, self.instance)
+        }
+    }
+}
+
 /// Declares what a pipeline node reads from and writes to the bus.
 ///
 /// `required_inputs` channels must have a declared producer in the graph for
@@ -100,7 +110,10 @@ impl PortBus {
     /// [`PortBus::clear_signals`]. All other slots use last-known-good semantics.
     /// The caller (typically [`PipelineBuilder`]) is responsible for classifying
     /// signals from the sensor suite configuration.
-    pub fn new(descriptors: &[PortDescriptor], signal_keys: Vec<ChannelKey>) -> Self {
+    pub fn new<'a>(
+        descriptors: impl IntoIterator<Item = &'a PortDescriptor>,
+        signal_keys: Vec<ChannelKey>,
+    ) -> Self {
         let mut slots = HashMap::new();
 
         for descriptor in descriptors {

--- a/helios_runtime/src/prelude.rs
+++ b/helios_runtime/src/prelude.rs
@@ -1,4 +1,6 @@
+pub use crate::pipeline::build_error::PipelineBuildError;
 pub use crate::pipeline::node::{NodeId, PipelineNode, TickContext};
+pub use crate::pipeline::{NodePipeline, NodePipelineBuilder};
 pub use crate::port::{ChannelKey, PortDescriptor};
 pub use crate::stamped::{Health, Stamped};
 
@@ -14,4 +16,4 @@ pub use crate::pipeline::{
 };
 pub use crate::runtime::AgentRuntime;
 pub use crate::stage::{LeveledController, LeveledPlanner, PipelineLevel};
-pub use crate::validation::{validate_autonomy_config, CapabilitySet, ValidationError};
+pub use crate::validation::{validate_autonomy_config, CapabilitySet, ConfigValidationError};

--- a/helios_runtime/src/prelude.rs
+++ b/helios_runtime/src/prelude.rs
@@ -1,5 +1,6 @@
 pub use crate::pipeline::build_error::PipelineBuildError;
-pub use crate::pipeline::node::{NodeId, PipelineNode, TickContext};
+pub use crate::pipeline::node::{NodeId, PipelineNode, TickContext, HOST_PRODUCER_ID};
+pub use crate::pipeline::node_pipeline::MISSION_GOAL_INSTANCE;
 pub use crate::pipeline::{NodePipeline, NodePipelineBuilder};
 pub use crate::port::{ChannelKey, PortDescriptor};
 pub use crate::stamped::{Health, Stamped};

--- a/helios_runtime/src/runtime.rs
+++ b/helios_runtime/src/runtime.rs
@@ -1,5 +1,3 @@
-// helios_runtime/src/runtime.rs
-//
 // AgentRuntime trait — the only interface the pipeline uses to query world state.
 // SimRuntime in helios_sim implements this for simulation.
 // On real hardware, a HardwareRuntime would implement it using sensor calibration data.

--- a/helios_runtime/src/validation.rs
+++ b/helios_runtime/src/validation.rs
@@ -13,7 +13,7 @@ pub struct CapabilitySet {
 
 /// Structured validation failure.
 #[derive(Debug)]
-pub enum ValidationError {
+pub enum ConfigValidationError {
     UnknownEstimator {
         kind: String,
     },
@@ -35,27 +35,31 @@ pub enum ValidationError {
     },
 }
 
-impl std::fmt::Display for ValidationError {
+impl std::fmt::Display for ConfigValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ValidationError::UnknownEstimator { kind } => {
+            ConfigValidationError::UnknownEstimator { kind } => {
                 write!(f, "Unknown estimator kind '{kind}'")
             }
-            ValidationError::UnknownDynamics { kind } => {
+            ConfigValidationError::UnknownDynamics { kind } => {
                 write!(f, "Unknown dynamics kind '{kind}'")
             }
-            ValidationError::UnknownController { kind } => {
+            ConfigValidationError::UnknownController { kind } => {
                 write!(f, "Unknown controller kind '{kind}'")
             }
-            ValidationError::UnknownControllerDynamics {
+            ConfigValidationError::UnknownControllerDynamics {
                 controller_kind,
                 dynamics_key,
             } => write!(
                 f,
                 "Controller '{controller_kind}' references unknown dynamics_key '{dynamics_key}'"
             ),
-            ValidationError::UnknownMapper { kind } => write!(f, "Unknown mapper kind '{kind}'"),
-            ValidationError::UnknownPlanner { kind } => write!(f, "Unknown planner kind '{kind}'"),
+            ConfigValidationError::UnknownMapper { kind } => {
+                write!(f, "Unknown mapper kind '{kind}'")
+            }
+            ConfigValidationError::UnknownPlanner { kind } => {
+                write!(f, "Unknown planner kind '{kind}'")
+            }
         }
     }
 }
@@ -65,14 +69,14 @@ impl std::fmt::Display for ValidationError {
 pub fn validate_autonomy_config(
     config: &AutonomyStack,
     capabilities: &CapabilitySet,
-) -> Vec<ValidationError> {
+) -> Vec<ConfigValidationError> {
     let mut errors = Vec::new();
 
     // Estimator validation
     if let Some(est_cfg) = &config.estimator {
         let kind = est_cfg.get_kind_str();
         if !capabilities.estimators.contains(kind) {
-            errors.push(ValidationError::UnknownEstimator {
+            errors.push(ConfigValidationError::UnknownEstimator {
                 kind: kind.to_string(),
             });
         }
@@ -80,7 +84,7 @@ pub fn validate_autonomy_config(
         if let crate::config::EstimatorConfig::Ekf(ekf) = est_cfg {
             let dyn_kind = ekf.dynamics.get_kind_str();
             if !capabilities.dynamics.contains(dyn_kind) {
-                errors.push(ValidationError::UnknownDynamics {
+                errors.push(ConfigValidationError::UnknownDynamics {
                     kind: dyn_kind.to_string(),
                 });
             }
@@ -91,7 +95,7 @@ pub fn validate_autonomy_config(
     for map_cfg in config.map_layers.values() {
         let kind = map_cfg.get_kind_str();
         if kind != "None" && !capabilities.mappers.contains(kind) {
-            errors.push(ValidationError::UnknownMapper {
+            errors.push(ConfigValidationError::UnknownMapper {
                 kind: kind.to_string(),
             });
         }
@@ -101,14 +105,14 @@ pub fn validate_autonomy_config(
     for ctrl_cfg in config.controllers.values() {
         let kind = ctrl_cfg.get_kind_str();
         if !capabilities.controllers.contains(kind) {
-            errors.push(ValidationError::UnknownController {
+            errors.push(ConfigValidationError::UnknownController {
                 kind: kind.to_string(),
             });
         }
         // FeedforwardPid references a dynamics_key that must also be registered
         if let ControllerConfig::FeedforwardPid { dynamics_key, .. } = ctrl_cfg {
             if !capabilities.dynamics.contains(dynamics_key.as_str()) {
-                errors.push(ValidationError::UnknownControllerDynamics {
+                errors.push(ConfigValidationError::UnknownControllerDynamics {
                     controller_kind: kind.to_string(),
                     dynamics_key: dynamics_key.clone(),
                 });
@@ -120,7 +124,7 @@ pub fn validate_autonomy_config(
     for plan_cfg in config.geometric_planners.values() {
         let kind = plan_cfg.get_kind_str();
         if !capabilities.planners.contains(kind) {
-            errors.push(ValidationError::UnknownPlanner {
+            errors.push(ConfigValidationError::UnknownPlanner {
                 kind: kind.to_string(),
             });
         }

--- a/helios_runtime/tests/integration.rs
+++ b/helios_runtime/tests/integration.rs
@@ -1,5 +1,7 @@
 #[path = "integration/common.rs"]
 mod common;
+#[path = "integration/dag.rs"]
+mod dag;
 #[path = "integration/pipeline.rs"]
 mod pipeline;
 #[path = "integration/stages.rs"]

--- a/helios_runtime/tests/integration/dag.rs
+++ b/helios_runtime/tests/integration/dag.rs
@@ -1,0 +1,552 @@
+// DAG execution engine tests (#35): builder validation, level ordering,
+// rate gating, and tick semantics.
+
+#![allow(dead_code)]
+
+use std::sync::{
+    atomic::{AtomicU32, Ordering},
+    Arc,
+};
+
+use helios_core::data::primitives::MonotonicTime;
+use helios_runtime::{
+    pipeline::{NodePipelineBuilder, PipelineBuildError},
+    port::{ChannelKey, PortBus, PortDescriptor},
+    prelude::{Health, PipelineNode, Stamped, TickContext},
+};
+
+use crate::common::MockRuntime;
+
+// =========================================================================
+// == Dummy PipelineNode implementations ==
+// =========================================================================
+
+/// Writes a fixed u32 value to a single output channel.
+struct ProducerNode {
+    name: String,
+    descriptor: PortDescriptor,
+    output: ChannelKey,
+    value: u32,
+}
+
+impl ProducerNode {
+    fn new(name: &str, output: ChannelKey, value: u32) -> Self {
+        Self {
+            name: name.to_string(),
+            descriptor: PortDescriptor {
+                required_inputs: vec![],
+                optional_inputs: vec![],
+                outputs: vec![output.clone()],
+                rate: None,
+            },
+            output,
+            value,
+        }
+    }
+}
+
+impl PipelineNode for ProducerNode {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn port_descriptor(&self) -> &PortDescriptor {
+        &self.descriptor
+    }
+
+    fn execute(&self, bus: &PortBus, _runtime: &dyn helios_runtime::prelude::AgentRuntime, tick: TickContext) {
+        let stamped = Stamped {
+            value: self.value,
+            timestamp: tick.now,
+            health: Health::Ok,
+            producer: tick.node_id,
+        };
+        let _ = bus.write(self.output.clone(), stamped);
+    }
+}
+
+/// Reads a u32 from `input`, applies a transform, writes to `output`.
+/// Early-returns if the input is not present — this is how we detect
+/// ordering violations (a chained node placed too early sees no input
+/// and produces nothing).
+struct TransformNode {
+    name: String,
+    descriptor: PortDescriptor,
+    input: ChannelKey,
+    output: ChannelKey,
+    transform: fn(u32) -> u32,
+}
+
+impl TransformNode {
+    fn new(name: &str, input: ChannelKey, output: ChannelKey, transform: fn(u32) -> u32) -> Self {
+        Self {
+            name: name.to_string(),
+            descriptor: PortDescriptor {
+                required_inputs: vec![input.clone()],
+                optional_inputs: vec![],
+                outputs: vec![output.clone()],
+                rate: None,
+            },
+            input,
+            output,
+            transform,
+        }
+    }
+}
+
+impl PipelineNode for TransformNode {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn port_descriptor(&self) -> &PortDescriptor {
+        &self.descriptor
+    }
+
+    fn execute(&self, bus: &PortBus, _runtime: &dyn helios_runtime::prelude::AgentRuntime, tick: TickContext) {
+        let Some(input) = bus.read::<u32>(self.input.clone()) else {
+            return;
+        };
+        let out = (self.transform)(input.value);
+        let stamped = Stamped {
+            value: out,
+            timestamp: tick.now,
+            health: Health::Ok,
+            producer: tick.node_id,
+        };
+        let _ = bus.write(self.output.clone(), stamped);
+    }
+}
+
+/// Reads two u32 inputs, sums them, writes to output.
+struct JoinNode {
+    name: String,
+    descriptor: PortDescriptor,
+    input_a: ChannelKey,
+    input_b: ChannelKey,
+    output: ChannelKey,
+}
+
+impl JoinNode {
+    fn new(name: &str, input_a: ChannelKey, input_b: ChannelKey, output: ChannelKey) -> Self {
+        Self {
+            name: name.to_string(),
+            descriptor: PortDescriptor {
+                required_inputs: vec![input_a.clone(), input_b.clone()],
+                optional_inputs: vec![],
+                outputs: vec![output.clone()],
+                rate: None,
+            },
+            input_a,
+            input_b,
+            output,
+        }
+    }
+}
+
+impl PipelineNode for JoinNode {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn port_descriptor(&self) -> &PortDescriptor {
+        &self.descriptor
+    }
+
+    fn execute(&self, bus: &PortBus, _runtime: &dyn helios_runtime::prelude::AgentRuntime, tick: TickContext) {
+        let Some(a) = bus.read::<u32>(self.input_a.clone()) else {
+            return;
+        };
+        let Some(b) = bus.read::<u32>(self.input_b.clone()) else {
+            return;
+        };
+        let stamped = Stamped {
+            value: a.value + b.value,
+            timestamp: tick.now,
+            health: Health::Ok,
+            producer: tick.node_id,
+        };
+        let _ = bus.write(self.output.clone(), stamped);
+    }
+}
+
+/// Increments a shared counter on every execute. Used for rate-gating tests.
+struct CountingNode {
+    name: String,
+    descriptor: PortDescriptor,
+    counter: Arc<AtomicU32>,
+}
+
+impl CountingNode {
+    fn new(name: &str, rate_hz: Option<f64>, counter: Arc<AtomicU32>) -> Self {
+        Self {
+            name: name.to_string(),
+            descriptor: PortDescriptor {
+                required_inputs: vec![],
+                optional_inputs: vec![],
+                outputs: vec![],
+                rate: rate_hz,
+            },
+            counter,
+        }
+    }
+}
+
+impl PipelineNode for CountingNode {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn port_descriptor(&self) -> &PortDescriptor {
+        &self.descriptor
+    }
+
+    fn execute(&self, _bus: &PortBus, _runtime: &dyn helios_runtime::prelude::AgentRuntime, _tick: TickContext) {
+        self.counter.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Node that requires an input but produces no output. Used when we need
+/// a consumer for a channel without writing anything back.
+struct SinkNode {
+    name: String,
+    descriptor: PortDescriptor,
+}
+
+impl SinkNode {
+    fn new(name: &str, input: ChannelKey) -> Self {
+        Self {
+            name: name.to_string(),
+            descriptor: PortDescriptor {
+                required_inputs: vec![input],
+                optional_inputs: vec![],
+                outputs: vec![],
+                rate: None,
+            },
+        }
+    }
+}
+
+impl PipelineNode for SinkNode {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn port_descriptor(&self) -> &PortDescriptor {
+        &self.descriptor
+    }
+
+    fn execute(&self, _bus: &PortBus, _runtime: &dyn helios_runtime::prelude::AgentRuntime, _tick: TickContext) {
+    }
+}
+
+// Tag types so each test can mint distinct ChannelKeys without colliding.
+struct ChA;
+struct ChB;
+struct ChC;
+struct ChD;
+struct Sensor;
+
+// =========================================================================
+// == Build-time validation ==
+// =========================================================================
+
+#[test]
+fn single_node_executes() {
+    let out = ChannelKey::of::<ChA>();
+    let pipeline = NodePipelineBuilder::new()
+        .add_node(Box::new(ProducerNode::new("a", out.clone(), 42)))
+        .build()
+        .expect("build should succeed");
+
+    pipeline.tick(&MockRuntime, 0.1);
+
+    let value = pipeline.bus().read::<u32>(out).expect("output should exist");
+    assert_eq!(value.value, 42);
+}
+
+#[test]
+fn two_node_chain_level_ordering() {
+    let a = ChannelKey::of::<ChA>();
+    let b = ChannelKey::of::<ChB>();
+
+    let pipeline = NodePipelineBuilder::new()
+        .add_node(Box::new(ProducerNode::new("a", a.clone(), 7)))
+        .add_node(Box::new(TransformNode::new(
+            "b",
+            a.clone(),
+            b.clone(),
+            |v| v * 2,
+        )))
+        .build()
+        .expect("build should succeed");
+
+    pipeline.tick(&MockRuntime, 0.1);
+
+    // If B were placed in level 0 alongside A, B would early-return (A's
+    // output not yet on the bus when B reads). Output present means B ran
+    // after A.
+    let result = pipeline.bus().read::<u32>(b).expect("b output should exist");
+    assert_eq!(result.value, 14);
+}
+
+#[test]
+fn two_node_chain_with_builder_inserted_out_of_order() {
+    // B added before A — toposort must still resolve A→B.
+    let a = ChannelKey::of::<ChA>();
+    let b = ChannelKey::of::<ChB>();
+
+    let pipeline = NodePipelineBuilder::new()
+        .add_node(Box::new(TransformNode::new(
+            "b",
+            a.clone(),
+            b.clone(),
+            |v| v + 1,
+        )))
+        .add_node(Box::new(ProducerNode::new("a", a.clone(), 10)))
+        .build()
+        .expect("build should succeed");
+
+    pipeline.tick(&MockRuntime, 0.1);
+
+    let result = pipeline.bus().read::<u32>(b).expect("b output should exist");
+    assert_eq!(result.value, 11);
+}
+
+#[test]
+fn three_node_diamond_resolves() {
+    // A → (B, C) → D, with D summing B and C's outputs.
+    let a = ChannelKey::of::<ChA>();
+    let b = ChannelKey::of::<ChB>();
+    let c = ChannelKey::of::<ChC>();
+    let d = ChannelKey::of::<ChD>();
+
+    let pipeline = NodePipelineBuilder::new()
+        .add_node(Box::new(ProducerNode::new("a", a.clone(), 1)))
+        .add_node(Box::new(TransformNode::new(
+            "b",
+            a.clone(),
+            b.clone(),
+            |v| v * 2,
+        )))
+        .add_node(Box::new(TransformNode::new(
+            "c",
+            a.clone(),
+            c.clone(),
+            |v| v * 3,
+        )))
+        .add_node(Box::new(JoinNode::new("d", b.clone(), c.clone(), d.clone())))
+        .build()
+        .expect("build should succeed");
+
+    pipeline.tick(&MockRuntime, 0.1);
+
+    // A=1, B=A*2=2, C=A*3=3, D=B+C=5.
+    let result = pipeline.bus().read::<u32>(d).expect("d output should exist");
+    assert_eq!(result.value, 5);
+}
+
+#[test]
+fn cycle_detected() {
+    // A requires B's output, B requires A's output.
+    let a_out = ChannelKey::named::<ChA>("a_out");
+    let b_out = ChannelKey::named::<ChB>("b_out");
+
+    let result = NodePipelineBuilder::new()
+        .add_node(Box::new(TransformNode::new(
+            "a",
+            b_out.clone(),
+            a_out.clone(),
+            |v| v,
+        )))
+        .add_node(Box::new(TransformNode::new(
+            "b",
+            a_out.clone(),
+            b_out.clone(),
+            |v| v,
+        )))
+        .build();
+
+    let Err(errors) = result else {
+        panic!("should fail with cycle");
+    };
+    assert!(
+        errors.iter().any(|e| matches!(e, PipelineBuildError::Cycle)),
+        "expected Cycle, got {:?}",
+        errors
+    );
+}
+
+#[test]
+fn unsatisfied_input_detected() {
+    let missing = ChannelKey::named::<ChA>("missing");
+    let out = ChannelKey::of::<ChB>();
+
+    let result = NodePipelineBuilder::new()
+        .add_node(Box::new(TransformNode::new(
+            "needs_missing",
+            missing.clone(),
+            out,
+            |v| v,
+        )))
+        .build();
+
+    let Err(errors) = result else {
+        panic!("should fail with unsatisfied input");
+    };
+    assert!(
+        errors.iter().any(|e| matches!(
+            e,
+            PipelineBuildError::UnsatisfiedInput { node_name, channel }
+                if node_name == "needs_missing" && *channel == missing
+        )),
+        "expected UnsatisfiedInput for 'needs_missing'/{missing:?}, got {errors:?}"
+    );
+}
+
+#[test]
+fn multiple_producers_detected() {
+    let shared = ChannelKey::of::<ChA>();
+
+    let result = NodePipelineBuilder::new()
+        .add_node(Box::new(ProducerNode::new("a", shared.clone(), 1)))
+        .add_node(Box::new(ProducerNode::new("b", shared.clone(), 2)))
+        .build();
+
+    let Err(errors) = result else {
+        panic!("should fail with multiple producers");
+    };
+    assert!(
+        errors.iter().any(|e| matches!(
+            e,
+            PipelineBuildError::MultipleProducers { channel, .. } if *channel == shared
+        )),
+        "expected MultipleProducers, got {errors:?}"
+    );
+}
+
+#[test]
+fn signal_keys_satisfy_required_inputs() {
+    // A node requires a sensor-injected channel that no node produces.
+    // Declaring it via with_sensor_signals must make the build succeed.
+    let sensor_key = ChannelKey::named::<Sensor>("imu");
+
+    let result = NodePipelineBuilder::new()
+        .add_node(Box::new(SinkNode::new("consumer", sensor_key.clone())))
+        .with_sensor_signals(vec![sensor_key])
+        .build();
+
+    assert!(result.is_ok(), "build should succeed: {:?}", result.err());
+}
+
+#[test]
+fn host_state_keys_satisfy_required_inputs() {
+    // Same as above but via with_host_states — a host-state channel
+    // (persists across ticks, no clear_signals) also seeds `produced`.
+    let host_key = ChannelKey::named::<ChA>("mission");
+
+    let result = NodePipelineBuilder::new()
+        .add_node(Box::new(SinkNode::new("planner", host_key.clone())))
+        .with_host_states(vec![host_key])
+        .build();
+
+    assert!(result.is_ok(), "build should succeed: {:?}", result.err());
+}
+
+// =========================================================================
+// == Rate gating ==
+// =========================================================================
+
+#[test]
+fn rate_gated_node_fires_at_correct_interval() {
+    // Period = 1 / 2 Hz = 0.5s. dt = 0.1s → fires on the 5th tick only.
+    let counter = Arc::new(AtomicU32::new(0));
+    let pipeline = NodePipelineBuilder::new()
+        .add_node(Box::new(CountingNode::new(
+            "rated",
+            Some(2.0),
+            counter.clone(),
+        )))
+        .build()
+        .expect("build should succeed");
+
+    for _ in 0..4 {
+        pipeline.tick(&MockRuntime, 0.1);
+    }
+    assert_eq!(counter.load(Ordering::Relaxed), 0, "must not fire before 0.5s elapsed");
+
+    pipeline.tick(&MockRuntime, 0.1);
+    assert_eq!(counter.load(Ordering::Relaxed), 1, "must fire on 5th tick");
+}
+
+#[test]
+fn rate_gated_node_does_not_double_fire() {
+    // dt = 1.0s with period = 0.5s would cover two periods; node must
+    // still fire exactly once (no catch-up).
+    let counter = Arc::new(AtomicU32::new(0));
+    let pipeline = NodePipelineBuilder::new()
+        .add_node(Box::new(CountingNode::new(
+            "rated",
+            Some(2.0),
+            counter.clone(),
+        )))
+        .build()
+        .expect("build should succeed");
+
+    pipeline.tick(&MockRuntime, 1.0);
+    assert_eq!(counter.load(Ordering::Relaxed), 1, "must fire exactly once on slow tick");
+}
+
+#[test]
+fn unrated_node_fires_every_tick() {
+    // rate: None means fire every tick.
+    let counter = Arc::new(AtomicU32::new(0));
+    let pipeline = NodePipelineBuilder::new()
+        .add_node(Box::new(CountingNode::new(
+            "every_tick",
+            None,
+            counter.clone(),
+        )))
+        .build()
+        .expect("build should succeed");
+
+    for _ in 0..3 {
+        pipeline.tick(&MockRuntime, 0.01);
+    }
+    assert_eq!(counter.load(Ordering::Relaxed), 3);
+}
+
+// =========================================================================
+// == Tick semantics ==
+// =========================================================================
+
+#[test]
+fn tick_does_not_clear_signals() {
+    // Signals are cleared only by explicit bus.clear_signals() — never
+    // by tick() itself.
+    let sensor_key = ChannelKey::named::<Sensor>("imu");
+    let pipeline = NodePipelineBuilder::new()
+        .add_node(Box::new(SinkNode::new("consumer", sensor_key.clone())))
+        .with_sensor_signals(vec![sensor_key.clone()])
+        .build()
+        .expect("build should succeed");
+
+    let stamped = Stamped {
+        value: 99u32,
+        timestamp: MonotonicTime(0.0),
+        health: Health::Ok,
+        producer: 0,
+    };
+    pipeline
+        .bus()
+        .write(sensor_key.clone(), stamped)
+        .expect("write should succeed");
+
+    pipeline.tick(&MockRuntime, 0.1);
+
+    let after = pipeline
+        .bus()
+        .read::<u32>(sensor_key)
+        .expect("signal should still be present after tick");
+    assert_eq!(after.value, 99);
+}

--- a/helios_runtime/tests/integration/dag.rs
+++ b/helios_runtime/tests/integration/dag.rs
@@ -54,7 +54,12 @@ impl PipelineNode for ProducerNode {
         &self.descriptor
     }
 
-    fn execute(&self, bus: &PortBus, _runtime: &dyn helios_runtime::prelude::AgentRuntime, tick: TickContext) {
+    fn execute(
+        &self,
+        bus: &PortBus,
+        _runtime: &dyn helios_runtime::prelude::AgentRuntime,
+        tick: TickContext,
+    ) {
         let stamped = Stamped {
             value: self.value,
             timestamp: tick.now,
@@ -103,7 +108,12 @@ impl PipelineNode for TransformNode {
         &self.descriptor
     }
 
-    fn execute(&self, bus: &PortBus, _runtime: &dyn helios_runtime::prelude::AgentRuntime, tick: TickContext) {
+    fn execute(
+        &self,
+        bus: &PortBus,
+        _runtime: &dyn helios_runtime::prelude::AgentRuntime,
+        tick: TickContext,
+    ) {
         let Some(input) = bus.read::<u32>(self.input.clone()) else {
             return;
         };
@@ -153,7 +163,12 @@ impl PipelineNode for JoinNode {
         &self.descriptor
     }
 
-    fn execute(&self, bus: &PortBus, _runtime: &dyn helios_runtime::prelude::AgentRuntime, tick: TickContext) {
+    fn execute(
+        &self,
+        bus: &PortBus,
+        _runtime: &dyn helios_runtime::prelude::AgentRuntime,
+        tick: TickContext,
+    ) {
         let Some(a) = bus.read::<u32>(self.input_a.clone()) else {
             return;
         };
@@ -201,7 +216,12 @@ impl PipelineNode for CountingNode {
         &self.descriptor
     }
 
-    fn execute(&self, _bus: &PortBus, _runtime: &dyn helios_runtime::prelude::AgentRuntime, _tick: TickContext) {
+    fn execute(
+        &self,
+        _bus: &PortBus,
+        _runtime: &dyn helios_runtime::prelude::AgentRuntime,
+        _tick: TickContext,
+    ) {
         self.counter.fetch_add(1, Ordering::Relaxed);
     }
 }
@@ -236,7 +256,12 @@ impl PipelineNode for SinkNode {
         &self.descriptor
     }
 
-    fn execute(&self, _bus: &PortBus, _runtime: &dyn helios_runtime::prelude::AgentRuntime, _tick: TickContext) {
+    fn execute(
+        &self,
+        _bus: &PortBus,
+        _runtime: &dyn helios_runtime::prelude::AgentRuntime,
+        _tick: TickContext,
+    ) {
     }
 }
 
@@ -261,7 +286,10 @@ fn single_node_executes() {
 
     pipeline.tick(&MockRuntime, 0.1);
 
-    let value = pipeline.bus().read::<u32>(out).expect("output should exist");
+    let value = pipeline
+        .bus()
+        .read::<u32>(out)
+        .expect("output should exist");
     assert_eq!(value.value, 42);
 }
 
@@ -286,7 +314,10 @@ fn two_node_chain_level_ordering() {
     // If B were placed in level 0 alongside A, B would early-return (A's
     // output not yet on the bus when B reads). Output present means B ran
     // after A.
-    let result = pipeline.bus().read::<u32>(b).expect("b output should exist");
+    let result = pipeline
+        .bus()
+        .read::<u32>(b)
+        .expect("b output should exist");
     assert_eq!(result.value, 14);
 }
 
@@ -309,7 +340,10 @@ fn two_node_chain_with_builder_inserted_out_of_order() {
 
     pipeline.tick(&MockRuntime, 0.1);
 
-    let result = pipeline.bus().read::<u32>(b).expect("b output should exist");
+    let result = pipeline
+        .bus()
+        .read::<u32>(b)
+        .expect("b output should exist");
     assert_eq!(result.value, 11);
 }
 
@@ -335,14 +369,22 @@ fn three_node_diamond_resolves() {
             c.clone(),
             |v| v * 3,
         )))
-        .add_node(Box::new(JoinNode::new("d", b.clone(), c.clone(), d.clone())))
+        .add_node(Box::new(JoinNode::new(
+            "d",
+            b.clone(),
+            c.clone(),
+            d.clone(),
+        )))
         .build()
         .expect("build should succeed");
 
     pipeline.tick(&MockRuntime, 0.1);
 
     // A=1, B=A*2=2, C=A*3=3, D=B+C=5.
-    let result = pipeline.bus().read::<u32>(d).expect("d output should exist");
+    let result = pipeline
+        .bus()
+        .read::<u32>(d)
+        .expect("d output should exist");
     assert_eq!(result.value, 5);
 }
 
@@ -371,7 +413,9 @@ fn cycle_detected() {
         panic!("should fail with cycle");
     };
     assert!(
-        errors.iter().any(|e| matches!(e, PipelineBuildError::Cycle)),
+        errors
+            .iter()
+            .any(|e| matches!(e, PipelineBuildError::Cycle)),
         "expected Cycle, got {:?}",
         errors
     );
@@ -473,7 +517,11 @@ fn rate_gated_node_fires_at_correct_interval() {
     for _ in 0..4 {
         pipeline.tick(&MockRuntime, 0.1);
     }
-    assert_eq!(counter.load(Ordering::Relaxed), 0, "must not fire before 0.5s elapsed");
+    assert_eq!(
+        counter.load(Ordering::Relaxed),
+        0,
+        "must not fire before 0.5s elapsed"
+    );
 
     pipeline.tick(&MockRuntime, 0.1);
     assert_eq!(counter.load(Ordering::Relaxed), 1, "must fire on 5th tick");
@@ -494,7 +542,11 @@ fn rate_gated_node_does_not_double_fire() {
         .expect("build should succeed");
 
     pipeline.tick(&MockRuntime, 1.0);
-    assert_eq!(counter.load(Ordering::Relaxed), 1, "must fire exactly once on slow tick");
+    assert_eq!(
+        counter.load(Ordering::Relaxed),
+        1,
+        "must fire exactly once on slow tick"
+    );
 }
 
 #[test]

--- a/helios_runtime/tests/integration/validation.rs
+++ b/helios_runtime/tests/integration/validation.rs
@@ -8,7 +8,7 @@ use helios_runtime::{
         GeometricPlannerConfig, ImuProcessNoiseConfig, MapLayerConfig, MapperPoseSourceConfig,
     },
     stage::PipelineLevel,
-    validation::{validate_autonomy_config, CapabilitySet, ValidationError},
+    validation::{validate_autonomy_config, CapabilitySet, ConfigValidationError},
 };
 
 // =========================================================================
@@ -132,9 +132,9 @@ fn validation_unknown_estimator_produces_error() {
     caps.estimators.clear();
     let errors = validate_autonomy_config(&stack, &caps);
     assert!(
-        errors
-            .iter()
-            .any(|e| matches!(e, ValidationError::UnknownEstimator { kind } if kind == "Ekf")),
+        errors.iter().any(
+            |e| matches!(e, ConfigValidationError::UnknownEstimator { kind } if kind == "Ekf")
+        ),
         "Expected UnknownEstimator for Ekf"
     );
 }
@@ -153,7 +153,7 @@ fn validation_unknown_dynamics_produces_error() {
     assert!(
         errors.iter().any(|e| matches!(
             e,
-            ValidationError::UnknownDynamics { kind } if kind == "IntegratedImu"
+            ConfigValidationError::UnknownDynamics { kind } if kind == "IntegratedImu"
         )),
         "Expected UnknownDynamics for IntegratedImu"
     );
@@ -174,7 +174,7 @@ fn validation_unknown_mapper_produces_error() {
     assert!(
         errors.iter().any(|e| matches!(
             e,
-            ValidationError::UnknownMapper { kind } if kind == "OccupancyGrid2D"
+            ConfigValidationError::UnknownMapper { kind } if kind == "OccupancyGrid2D"
         )),
         "Expected UnknownMapper for OccupancyGrid2D"
     );
@@ -190,9 +190,9 @@ fn validation_unknown_controller_produces_error() {
     };
     let errors = validate_autonomy_config(&stack, &empty_caps());
     assert!(
-        errors
-            .iter()
-            .any(|e| matches!(e, ValidationError::UnknownController { kind } if kind == "Pid")),
+        errors.iter().any(
+            |e| matches!(e, ConfigValidationError::UnknownController { kind } if kind == "Pid")
+        ),
         "Expected UnknownController for Pid"
     );
 }
@@ -207,9 +207,9 @@ fn validation_unknown_planner_produces_error() {
     };
     let errors = validate_autonomy_config(&stack, &empty_caps());
     assert!(
-        errors
-            .iter()
-            .any(|e| matches!(e, ValidationError::UnknownPlanner { kind } if kind == "AStar")),
+        errors.iter().any(
+            |e| matches!(e, ConfigValidationError::UnknownPlanner { kind } if kind == "AStar")
+        ),
         "Expected UnknownPlanner for AStar"
     );
 }
@@ -240,7 +240,7 @@ fn validation_feedforward_pid_unknown_dynamics_key_produces_error() {
     assert!(
         errors.iter().any(|e| matches!(
             e,
-            ValidationError::UnknownControllerDynamics { dynamics_key, .. }
+            ConfigValidationError::UnknownControllerDynamics { dynamics_key, .. }
                 if dynamics_key == "MyCustomDynamics"
         )),
         "Expected UnknownControllerDynamics for MyCustomDynamics"


### PR DESCRIPTION
#35
* Node Pipeline Builder. It will be renamed AutonomyPipelineBuilder to replace the current hardcoded version
* Renamed ValidationError to ConfigValidationError
* Created PipelineBuilderError to debug issues
* Create a RateTimer to run each node at a particular rate
* Display for ChannelKey
* Dag tests